### PR TITLE
Services for webapi plugin

### DIFF
--- a/apps/cloud/src/api/task.ts
+++ b/apps/cloud/src/api/task.ts
@@ -4,7 +4,8 @@
 import * as express from 'express';
 import Store from '@raincatcher/store';
 // Express.js based out of the box api service
-import webapi, {WebApiConfig} from '@raincatcher/webapi';
+import webapi, {WebApiConfig, ApiService, StoreApiService}  from '@raincatcher/webapi';
+
 
 // Define new datatype
 interface Task {
@@ -26,6 +27,10 @@ const sampleTask: Task = {
 };
 
 let taskStore = new Store<Task>([sampleTask]);
-let taskRouter: express.Router = webapi(taskStore, config);
+// This example is simple but it shows alternative way for developers to extend module functionality.
+// Service by default wrapes store, but developers can extend store (or just particular methods)
+// To provide custome functionality additionally some different store can be injected into implementation.
+let taskService = new StoreApiService<Task>(taskStore);
+let taskRouter: express.Router = webapi(taskService, config);
 
 export default taskRouter;

--- a/packages/webapi/package.json
+++ b/packages/webapi/package.json
@@ -9,12 +9,14 @@
     "@raincatcher/store": "1.0.0",
     "bunyan": "^1.8.10",
     "express": "^4.14.0",
-    "request": "^2.75.0"
+    "request": "^2.75.0",
+    "bluebird": "^3.5.0"
   },
   "scripts": {
     "prepublish": "del lib types && tsc"
   },
   "devDependencies": {
+    "@types/bluebird": "^3.5.3",
     "@types/bunyan": "0.0.36",
     "@types/express": "^4.0.35",
     "@types/node": "^7.0.14",

--- a/packages/webapi/src/index.ts
+++ b/packages/webapi/src/index.ts
@@ -1,6 +1,7 @@
 import * as express from 'express';
 import { Store, HasId } from '@raincatcher/store';
 import * as Logger from "bunyan";
+import {ApiService, StoreApiService} from "./service";
 
 var log = Logger.createLogger({name: __filename, level:"debug"});
 
@@ -33,7 +34,7 @@ export function loggerMiddleware(req: any, res: any) {
  * @param config - module configuration
  * @return router - router that can be mounted in top level application
  */
-export default function apiModule<T extends HasId>(store: Store<T>, config: WebApiConfig) {
+export default function apiModule<T extends HasId>(store: ApiService<T>, config: WebApiConfig) {
   const router: express.Router = express.Router();
   const route = router.route('/');
   log.info("Creating new api mount", { config: config });
@@ -63,4 +64,5 @@ export default function apiModule<T extends HasId>(store: Store<T>, config: WebA
   return router;
 };
 
+export * from "./service";
  

--- a/packages/webapi/src/service.ts
+++ b/packages/webapi/src/service.ts
@@ -1,0 +1,35 @@
+import RaincatcherStore, { Store, HasId } from '@raincatcher/store';
+import * as Logger from "bunyan";
+import * as Promise from 'bluebird';
+
+var log = Logger.createLogger({name: __filename, level:"debug"});
+
+/**
+ * WebApi Service interface that can be used to define custom data handlers
+ */
+export interface ApiService<T extends HasId> extends Store<T>{
+}
+
+export class StoreApiService<T extends HasId> implements ApiService<T> {
+  store: Store<T>
+
+  constructor(store?: Store<T>) {
+    this.store=store;
+  };
+
+  list() {
+   return this.store.list() as Promise<T[]>;
+  };
+
+  listWithCondition(condition: Object, limit: number) {
+    return this.store.list() as Promise<T[]>;
+  };
+
+  add(user: T) {
+    return  this.store.add(user) as Promise<T>;
+  };
+
+  reset() {
+    return this.store.reset() as Promise<T[]>;
+  }
+}


### PR DESCRIPTION
## Motivation

Add service layer between store and rest controllers. Injecting different services will allow users to modify module behaviors without forking and modifying code.Service can be used to change default behavior, while still sharing the same store implementation across the object. 

Functionality can be changed at any level for different storage solutions.
`Controller -> Service -> Storage`

ping @nialldonnellyfh @paolobueno @witmicko @austincunningham @JameelB 