### PR TITLE
[RAINCATCH 853] Types for raincatcher-mongoose

### DIFF
--- a/packages/types/mongoose-store/index.ts
+++ b/packages/types/mongoose-store/index.ts
@@ -1,49 +1,64 @@
+import * as Promise from 'bluebird';
 import * as mongoose from 'mongoose';
 
 export default class MongooseStore<T>{
-  // TODO
+  constructor(protected conn: mongoose.Connection) {
+
+  }
 }
 
 type ID = string | number;
 
 export interface Store<T> {
-  query(): ChainQuery<T>;
-  find(query: QueryParams<T>);
+  query(): ExecutableChainQuery<T>;
+  or(): ChainQuery<T>;
+  find(query: QueryParams<T>): Promise<T[]>;
   create(data: T): Promise<T>;
   update(id: ID, data: T): Promise<T>;
   delete(id: ID): Promise<T>;
 }
 
 interface Predicate<T> {
+  // An object with the same keys as T,
+  // with the same types as the corresponding property of T
   eq?: { [K in keyof T]?: T[K] };
   ne?: { [K in keyof T]?: T[K] };
   gt?: { [K in keyof T]?: T[K] };
   gte?: { [K in keyof T]?: T[K] };
   lt?: { [K in keyof T]?: T[K] };
   lte?: { [K in keyof T]?: T[K] };
+  matches?: { [K in keyof T]?: RegExp };
+
+  or?: Predicate<T>;
 }
 
 interface QueryParams<T> {
-  where: Predicate<T> | { or: Array<Predicate<T>> };
+  where: Predicate<T>;
   limit?: number;
   skip?: number;
   sort?: { [K in keyof T]?: 'asc' | 'desc' | ((value: T[K]) => number) };
 }
 
-export interface ChainQuery<T> {
+interface ChainQuery<T> {
+  // For any supplied key of T,
+  // take a value with the same type as the corresponding property of T
   where<K extends keyof T>(key: K, value: T[K]): this;
   gt<K extends keyof T>(key: K, value: T[K]): this;
   gte<K extends keyof T>(key: K, value: T[K]): this;
   lt<K extends keyof T>(key: K, value: T[K]): this;
   lte<K extends keyof T>(key: K, value: T[K]): this;
   ne<K extends keyof T>(key: K, value: T[K]): this;
-  or(other: ChainQuery<T>);
+  matches<K extends keyof T>(key: K, value: RegExp): this;
+  or(other: ChainQuery<T>): this;
 
   limit(max: number): this;
   skip(amount: number): this;
 
   sort<K extends keyof T>(key: K, value: 'asc' | 'desc'): this;
-  sortBy<K extends keyof T>(key: K, by: (value: T[K]) => number);
+  sortBy<K extends keyof T>(key: K, by: (value: T[K]) => number): this;
+}
+
+interface ExecutableChainQuery<T> extends ChainQuery<T> {
   get(): Promise<T[]>;
   getSingle(): Promise<T>;
 }

--- a/packages/types/mongoose-store/index.ts
+++ b/packages/types/mongoose-store/index.ts
@@ -1,0 +1,49 @@
+import * as mongoose from 'mongoose';
+
+export default class MongooseStore<T>{
+  // TODO
+}
+
+type ID = string | number;
+
+export interface Store<T> {
+  query(): ChainQuery<T>;
+  find(query: QueryParams<T>);
+  create(data: T): Promise<T>;
+  update(id: ID, data: T): Promise<T>;
+  delete(id: ID): Promise<T>;
+}
+
+interface Predicate<T> {
+  eq?: { [K in keyof T]?: T[K] };
+  ne?: { [K in keyof T]?: T[K] };
+  gt?: { [K in keyof T]?: T[K] };
+  gte?: { [K in keyof T]?: T[K] };
+  lt?: { [K in keyof T]?: T[K] };
+  lte?: { [K in keyof T]?: T[K] };
+}
+
+interface QueryParams<T> {
+  where: Predicate<T> | { or: Array<Predicate<T>> };
+  limit?: number;
+  skip?: number;
+  sort?: { [K in keyof T]?: 'asc' | 'desc' | ((value: T[K]) => number) };
+}
+
+export interface ChainQuery<T> {
+  where<K extends keyof T>(key: K, value: T[K]): this;
+  gt<K extends keyof T>(key: K, value: T[K]): this;
+  gte<K extends keyof T>(key: K, value: T[K]): this;
+  lt<K extends keyof T>(key: K, value: T[K]): this;
+  lte<K extends keyof T>(key: K, value: T[K]): this;
+  ne<K extends keyof T>(key: K, value: T[K]): this;
+  or(other: ChainQuery<T>);
+
+  limit(max: number): this;
+  skip(amount: number): this;
+
+  sort<K extends keyof T>(key: K, value: 'asc' | 'desc'): this;
+  sortBy<K extends keyof T>(key: K, by: (value: T[K]) => number);
+  get(): Promise<T[]>;
+  getSingle(): Promise<T>;
+}

--- a/packages/types/mongoose-store/usage.ts
+++ b/packages/types/mongoose-store/usage.ts
@@ -6,21 +6,58 @@ interface User {
   id: string;
   name: string;
   age: number;
+  todos: Todos[];
   getFullName: () => string;
 }
 
-const store: Store<User> = null; // = new MongooseStore<User>(mongoose.createConnection('localhost'));
+interface Todos {
+  id: string;
+  what: string;
+  deadline: Date;
+  userId: string;
+  pastDeadline: (when: Date) => boolean;
+}
 
-// Fluent interface example
-store.query()
-  .where('name', 'john')
-  .gt('age', 18)
-  .getSingle().then((u) => console.log(u.age));
+describe('Store Interface', function() {
+  const store: Store<User> = null; // = new MongooseStore<User>(mongoose.createConnection('localhost'));
 
-// Mongoose-style large query object example
-store.find({
-  where: {
-    eq: { name: 'john' },
-    gt: { age: 18 }
-  }
+  it('should showcase a chainable query interface', function() {
+    // Fluent interface example
+    return store.query()
+      .where('name', 'jon')
+      .gt('age', 18)
+      // .gt('age', 'foo') => Argument of type '"foo"' is not assignable to parameter of type 'number'.
+      .or(store.or().where('name', 'snow'))
+      .getSingle().tap((u) => console.log(u.age));
+  });
+  it('should showcase a object-based query interface', function() {
+    // Mongoose-style large query object example
+    return store.find({
+      where: {
+        eq: { name: 'jon' },
+        gt: { age: 18 },
+        or: {
+          eq: { name: 'snow' }
+        }
+      }
+    });
+  });
+  it('should allow query filters for sub-models');
+  it('should allow for batch creation of sub-models');
+  it('should allow for default values');
+  it('should be able to define runtime validations');
+  it('should emit events before create');
+  it('should emit events before update');
+  it('should emit events before delete');
+  it('should emit events after create');
+  it('should emit events after update');
+  it('should emit events after delete');
+});
+
+describe('MongooseStore', function() {
+  let store: MongooseStore<User>;
+  it('should receive mongoose-specific params on the constructor', function() {
+    store = new MongooseStore<User>(mongoose.createConnection('mongodb://localhost'));
+  });
+  it('should allow for supplying a Schema for T');
 });

--- a/packages/types/mongoose-store/usage.ts
+++ b/packages/types/mongoose-store/usage.ts
@@ -1,0 +1,26 @@
+import * as mongoose from 'mongoose';
+
+import MongooseStore, { Store } from './index';
+
+interface User {
+  id: string;
+  name: string;
+  age: number;
+  getFullName: () => string;
+}
+
+const store: Store<User> = null; // = new MongooseStore<User>(mongoose.createConnection('localhost'));
+
+// Fluent interface example
+store.query()
+  .where('name', 'john')
+  .gt('age', 18)
+  .getSingle().then((u) => console.log(u.age));
+
+// Mongoose-style large query object example
+store.find({
+  where: {
+    eq: { name: 'john' },
+    gt: { age: 18 }
+  }
+});

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,7 +9,6 @@
   "devDependencies": {
     "@types/bluebird": "^3.5.4",
     "@types/mongoose": "^4.7.12",
-    "mongoose": "^4.9.10",
     "typescript": "^2.3.2"
   },
   "dependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@raincatcher/types",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {},
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/bluebird": "^3.5.4",
+    "@types/mongoose": "^4.7.12",
+    "mongoose": "^4.9.10",
+    "typescript": "^2.3.2"
+  },
+  "dependencies": {
+    "bluebird": "^3.5.0",
+    "mongoose": "^4.9.10"
+  }
+}


### PR DESCRIPTION
## What
- Added `packages/types` as a scratchpad for the new APIs for the modules
- Added `packages/types/mongoose-store` with an reimplementable api and a mongoose-specific one for our implementation, heavily based on mongoose itself and the feathersjs services and querying capabilities.

The interface definitions are using some advanced typing features, but the tradeoff is that we gain a lot of strong typing on top of the models that are just POJO classes. And I hope that they make enough sense that actually implementing them wouldn't be that hard.